### PR TITLE
Fix chat width and scrolling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -281,6 +281,7 @@ button:focus-visible {
   .sidebar-open .max-w-5xl {
     margin-left: 20rem;
     margin-right: 1rem;
+    width: calc(100% - var(--sidebar-width) - 1rem);
     max-width: none;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   }
@@ -365,6 +366,7 @@ button:focus-visible {
     width: 100%;
     position: relative;
     max-width: 100%;
+    scrollbar-gutter: stable;
     transition: all 0.3s ease-in-out;
     overflow-x: hidden;
   }

--- a/components/chat-interface.tsx
+++ b/components/chat-interface.tsx
@@ -7,6 +7,7 @@ import { AnimatePresence, motion } from "framer-motion"
 import { Send, ArrowLeft, Menu, FileText, ChevronRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { SuggestedQuestions } from "@/components/suggested-questions"
 import { ChatHeader } from "@/components/chat-header"
 import { MessageBubble } from "@/components/message-bubble"
@@ -165,7 +166,7 @@ export function ChatInterface({ initialMessages = [], chatId }: ChatInterfacePro
   // `sidebar-open` class (managed via `useEffect` above) for width
   // adjustments when the sidebar is visible.
   const chatContainerClasses =
-    "chat-container h-full flex flex-col justify-between max-w-5xl mx-auto px-4";
+    "chat-container h-full flex flex-col justify-between max-w-5xl w-full mx-auto px-4";
 
   if (!showFullChat) {
     return (
@@ -295,7 +296,8 @@ export function ChatInterface({ initialMessages = [], chatId }: ChatInterfacePro
         </motion.div>
 
         {/* Messages Area */}
-        <div className="flex-1 flex flex-col overflow-y-auto overflow-x-hidden p-6 space-y-6 bg-slate-800/10 backdrop-blur-xl custom-scrollbar w-full">
+        <ScrollArea className="flex-1 overflow-y-auto">
+          <div className="flex flex-col p-6 space-y-6 bg-slate-800/10 backdrop-blur-xl custom-scrollbar w-full">
           {errorMessage && (
             <motion.div
               initial={{ opacity: 0, y: 10 }}
@@ -344,12 +346,13 @@ export function ChatInterface({ initialMessages = [], chatId }: ChatInterfacePro
 
           {/* Hide suggestions when inside a chat */}
           {!showFullChat && messages.length > 0 && messages.length < 4 && !isLoading && (
-            <SuggestedQuestions 
-              isFirstMessage={false} 
+            <SuggestedQuestions
+              isFirstMessage={false}
               onQuestionClick={handleSuggestedQuestion}
               sidebarOpen={sidebarOpen} />
           )}
-        </div>
+          </div>
+        </ScrollArea>
 
         {/* Input Area pinned to bottom */}
         <motion.div


### PR DESCRIPTION
## Summary
- make chat container always fill width
- update sidebar-open layout rule for width calculation
- keep layout stable with `scrollbar-gutter`
- scroll messages area using ScrollArea

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68448fd55884832da521458f4f340729