### PR TITLE
Fix mobile auto-scroll when starting new chat

### DIFF
--- a/components/mobile-viewport-fix.tsx
+++ b/components/mobile-viewport-fix.tsx
@@ -43,7 +43,13 @@ export default function MobileViewportFix() {
       if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA') {
         handleKeyboardVisibility(true)
         requestAnimationFrame(() => {
-          target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+          const chatContent = document.querySelector('.chat-content') as HTMLElement | null
+          const atTop = window.scrollY <= 0
+          const hasScrollableContent =
+            chatContent && chatContent.scrollHeight > chatContent.clientHeight + 10
+          if (!atTop && hasScrollableContent) {
+            target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+          }
         })
       }
     }


### PR DESCRIPTION
## Summary
- adjust mobile scroll handler so first message doesn't hide the header

## Testing
- `npx prettier --write components/mobile-viewport-fix.tsx`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684f8e9a9eb4832d97243693e02d9a16