### PR TITLE
Fix mobile auto scroll overshoot

### DIFF
--- a/components/mobile-viewport-fix.tsx
+++ b/components/mobile-viewport-fix.tsx
@@ -43,6 +43,9 @@ export default function MobileViewportFix() {
       if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA') {
         handleKeyboardVisibility(true)
         requestAnimationFrame(() => {
+          const pageScrollable = document.documentElement.scrollHeight > window.innerHeight
+          if (window.scrollY === 0 && !pageScrollable) return
+
           target.scrollIntoView({ behavior: 'smooth', block: 'center' })
         })
       }


### PR DESCRIPTION
## Summary
- skip `scrollIntoView` if page isn't scrollable or is already at top

## Testing
- `npx prettier --write components/mobile-viewport-fix.tsx`
- `npm run format:check` *(fails: Code style issues found in 20 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_684f8e9a9eb4832d97243693e02d9a16