### PR TITLE
Fix mobile header and input stickiness

### DIFF
--- a/styles/mobile-fixes.css
+++ b/styles/mobile-fixes.css
@@ -30,7 +30,7 @@ main {
 
 /* Header styling */
 .chat-page-header {
-  position: absolute;
+  position: sticky;
   top: 0;
   left: 0;
   right: 0;
@@ -57,7 +57,7 @@ main {
 
 /* Input area */
 .input-area {
-  position: absolute;
+  position: sticky;
   bottom: 0;
   left: 0;
   right: 0;
@@ -82,7 +82,7 @@ main {
     }
 
     .chat-page-header {
-      position: absolute;
+      /* Preserve sticky positioning when keyboard is visible */
     }
   }
 }


### PR DESCRIPTION
## Summary
- keep chat page header sticky at the top on mobile
- make mobile input area sticky at the bottom
- remove absolute positioning for the header when keyboard is open

## Testing
- `npm run build` *(fails: npm run lint requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_684fa5b8378c832d9dfa23243cb8f7fe