### PR TITLE
Fix chat viewport variable on mobile

### DIFF
--- a/styles/mobile-fixes.css
+++ b/styles/mobile-fixes.css
@@ -72,7 +72,7 @@ main {
 @media (max-width: 768px) {
   .keyboard-visible {
     .chat-content {
-      height: var(--viewport-height);
+      height: var(--app-height);
       padding-bottom: 60px;
     }
 


### PR DESCRIPTION
## Summary
- correct CSS variable to ensure chat area resizes properly when mobile keyboard opens

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684fa439a418832db74a482b5fd92094