### PR TITLE
Limit PDF dock dropdown height

### DIFF
--- a/components/pdf-dock.tsx
+++ b/components/pdf-dock.tsx
@@ -85,7 +85,7 @@ export const MobilePdfDockButton: React.FC = () => {
             className="absolute right-0 mt-12 w-56 z-50"
             style={{ transformOrigin: 'top right' }}
           >
-            <div className="bg-card border border-border rounded-xl p-2 shadow-2xl space-y-2">
+            <div className="bg-card border border-border rounded-xl p-2 shadow-2xl space-y-2 max-h-[70vh] overflow-y-auto">
               {items.map(item => (
                 <div key={item.id} className="flex items-center justify-between gap-2">
                   <button
@@ -207,7 +207,7 @@ export const DesktopPdfDockButton: React.FC = () => {
             className="absolute right-0 mt-10 w-72 z-50"
             style={{ transformOrigin: 'top right' }}
           >
-            <div className="bg-card border border-border rounded-xl p-2 shadow-lg space-y-2">
+            <div className="bg-card border border-border rounded-xl p-2 shadow-lg space-y-2 max-h-[70vh] overflow-y-auto">
               {items.map(item => (
                 <div key={item.id} className="flex items-center justify-between gap-2">
                   <button

--- a/components/pdf-dock.tsx
+++ b/components/pdf-dock.tsx
@@ -82,8 +82,8 @@ export const MobilePdfDockButton: React.FC = () => {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: -6 }}
             transition={{ type: 'spring', stiffness: 300, damping: 28 }}
-            className="absolute right-0 mt-12 w-56 z-50"
-            style={{ transformOrigin: 'top right' }}
+            className="absolute left-0 mt-12 w-56 z-50"
+            style={{ transformOrigin: 'top left' }}
           >
             <div className="bg-card border border-border rounded-xl p-2 shadow-2xl space-y-2 max-h-[70vh] overflow-y-auto">
               {items.map(item => (
@@ -204,8 +204,8 @@ export const DesktopPdfDockButton: React.FC = () => {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: -6 }}
             transition={{ type: 'spring', stiffness: 300, damping: 28 }}
-            className="absolute right-0 mt-10 w-72 z-50"
-            style={{ transformOrigin: 'top right' }}
+            className="absolute left-0 mt-10 w-72 z-50"
+            style={{ transformOrigin: 'top left' }}
           >
             <div className="bg-card border border-border rounded-xl p-2 shadow-lg space-y-2 max-h-[70vh] overflow-y-auto">
               {items.map(item => (


### PR DESCRIPTION
## Summary
- add scrollable max-height to the Open PDFs dropdown menus
- prevent long PDF lists from extending beyond the viewport on mobile and desktop

## Testing
- npm run lint *(fails: Cannot find module 'workflow/next' when loading next.config.compiled.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b81a03284832d83646ed6d7a206f9)