### PR TITLE
Keep API paper scrapers active without browser fallback

### DIFF
--- a/app/api/public/papers/search/route.ts
+++ b/app/api/public/papers/search/route.ts
@@ -1,12 +1,37 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { scrapePapersService } from '@/lib/scrapers/papers-scraper'
-import { scrapePapersCodeChef } from '@/lib/scrapers/papers-codechef'
-import { scrapeVITPaperVault } from '@/lib/scrapers/vit-papervault'
-import { scrapeExamCooker } from '@/lib/scrapers/examcooker'
 import { getCourseCode } from '@/lib/question-generator'
 import { getAllCourseMatches } from '@/lib/course-map'
 
 export const runtime = 'nodejs'
+
+const paperScrapingEnabled = process.env.ENABLE_PAPER_SCRAPING === 'true'
+
+type PaperScrapers = {
+  scrapePapersService: typeof import('@/lib/scrapers/papers-scraper').scrapePapersService
+  scrapePapersCodeChef: typeof import('@/lib/scrapers/papers-codechef').scrapePapersCodeChef
+  scrapeVITPaperVault: typeof import('@/lib/scrapers/vit-papervault').scrapeVITPaperVault
+  scrapeExamCooker: typeof import('@/lib/scrapers/examcooker').scrapeExamCooker
+}
+
+let scraperPromise: Promise<PaperScrapers> | null = null
+
+async function loadScrapers(): Promise<PaperScrapers> {
+  if (!scraperPromise) {
+    scraperPromise = Promise.all([
+      import('@/lib/scrapers/papers-scraper'),
+      import('@/lib/scrapers/papers-codechef'),
+      import('@/lib/scrapers/vit-papervault'),
+      import('@/lib/scrapers/examcooker'),
+    ]).then(([paperScraper, codeChef, vitPaperVault, examCooker]) => ({
+      scrapePapersService: paperScraper.scrapePapersService,
+      scrapePapersCodeChef: codeChef.scrapePapersCodeChef,
+      scrapeVITPaperVault: vitPaperVault.scrapeVITPaperVault,
+      scrapeExamCooker: examCooker.scrapeExamCooker,
+    }))
+  }
+
+  return scraperPromise
+}
 
 export async function GET(req: NextRequest) {
   const started = Date.now()
@@ -44,25 +69,33 @@ export async function GET(req: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-            error: 'unresolved_course_code',
-            input: courseInput,
-            message: `Could not resolve a valid course code for "${courseInput}"`,
-            suggestions: [
-              'Use the exact VIT course code (e.g., BCSE302L)',
-              'Try a different spelling of the course name',
-              'Provide at least 2 distinctive words from the course title',
-            ],
+          error: 'unresolved_course_code',
+          input: courseInput,
+          message: `Could not resolve a valid course code for "${courseInput}"`,
+          suggestions: [
+            'Use the exact VIT course code (e.g., BCSE302L)',
+            'Try a different spelling of the course name',
+            'Provide at least 2 distinctive words from the course title',
+          ],
         },
         { status: 400 }
       )
     }
 
-    const results = await Promise.allSettled([
+    const { scrapePapersService, scrapePapersCodeChef, scrapeVITPaperVault, scrapeExamCooker } = await loadScrapers()
+
+    const sourcesToUse = [
       scrapePapersService(resolvedCourseCode, examType, year),
-      scrapePapersCodeChef(resolvedCourseCode, examType, year),
-      scrapeVITPaperVault(resolvedCourseCode, examType, year),
+      scrapePapersCodeChef(resolvedCourseCode, examType, year, {
+        enableBrowserFallback: paperScrapingEnabled,
+      }),
+      scrapeVITPaperVault(resolvedCourseCode, examType, year, {
+        enableBrowserFallback: paperScrapingEnabled,
+      }),
       scrapeExamCooker(resolvedCourseCode, examType, year),
-    ])
+    ]
+
+    const results = await Promise.allSettled(sourcesToUse)
 
     const papers: any[] = []
     const sources: string[] = []

--- a/lib/scrapers/papers-codechef.ts
+++ b/lib/scrapers/papers-codechef.ts
@@ -1,5 +1,3 @@
-import puppeteer from 'puppeteer-core'
-import chromium from '@sparticuz/chromium'
 import { findFullCourseName } from '../course-map'
 
 const DEBUG_PAPERS =
@@ -78,7 +76,8 @@ function deduplicatePapers(papers: Paper[]): Paper[] {
 export async function scrapePapersCodeChef(
   courseCode: string,
   examType?: string,
-  year?: string
+  year?: string,
+  options?: { enableBrowserFallback?: boolean }
 ): Promise<ScraperResult> {
   try {
     dbg('start', { courseCode, examType, year })
@@ -93,6 +92,14 @@ export async function scrapePapersCodeChef(
 
     if (apiResult.success) {
       return apiResult
+    }
+
+    if (options?.enableBrowserFallback === false) {
+      return {
+        ...apiResult,
+        success: false,
+        error: apiResult.error || 'Browser scraping disabled',
+      }
     }
 
     dbg('API failed, falling back to browser scraping')
@@ -419,6 +426,11 @@ async function tryBrowserScraping(
 ): Promise<ScraperResult> {
   let browser
   try {
+    const [{ default: puppeteer }, { default: chromium }] = await Promise.all([
+      import('puppeteer-core'),
+      import('@sparticuz/chromium'),
+    ])
+
     dbg('launching puppeteer for browser scraping')
     browser = await puppeteer.launch({
       args: [...chromium.args, '--no-sandbox', '--disable-dev-shm-usage'],

--- a/lib/scrapers/papers-codechef.ts
+++ b/lib/scrapers/papers-codechef.ts
@@ -614,6 +614,11 @@ async function extractFinalUrlFromPaperPage(paperPageUrl: string): Promise<strin
   try {
     await new Promise(resolve => setTimeout(resolve, 200)) // Reduced from 500ms
 
+    const [{ default: puppeteer }, { default: chromium }] = await Promise.all([
+      import('puppeteer-core'),
+      import('@sparticuz/chromium'),
+    ])
+
     browser = await puppeteer.launch({
       args: [...chromium.args, '--no-sandbox', '--disable-dev-shm-usage'],
       defaultViewport: { width: 1280, height: 1024 },

--- a/lib/scrapers/vit-papervault.ts
+++ b/lib/scrapers/vit-papervault.ts
@@ -1,13 +1,24 @@
-import puppeteer from 'puppeteer-core'
-import chromium from '@sparticuz/chromium'
 import { findFullCourseName } from '../course-map'
 
-export async function scrapeVITPaperVault(courseCode: string, examType?: string, year?: string) {
+export async function scrapeVITPaperVault(
+  courseCode: string,
+  examType?: string,
+  year?: string,
+  options?: { enableBrowserFallback?: boolean }
+) {
   try {
     const apiResult = await tryVITVaultListAPI(courseCode, examType, year)
 
     if (apiResult.success) {
       return apiResult
+    }
+
+    if (options?.enableBrowserFallback === false) {
+      return {
+        ...apiResult,
+        success: false,
+        error: apiResult.error || 'Browser scraping disabled',
+      }
     }
 
     console.log('[vitpapervault] API failed, falling back to browser scraping')
@@ -82,6 +93,11 @@ async function tryVITVaultListAPI(courseCode: string, examType?: string, year?: 
 async function tryBrowserScraping(courseCode: string, examType?: string, year?: string) {
   let browser
   try {
+    const [{ default: puppeteer }, { default: chromium }] = await Promise.all([
+      import('puppeteer-core'),
+      import('@sparticuz/chromium'),
+    ])
+
     browser = await puppeteer.launch({
       args: chromium.args,
       defaultViewport: { width: 1280, height: 1024 },

--- a/lib/scrapers/vit-papervault.ts
+++ b/lib/scrapers/vit-papervault.ts
@@ -83,10 +83,12 @@ async function tryVITVaultListAPI(courseCode: string, examType?: string, year?: 
       papers: papers.slice(0, 100),
       source: 'vitpapervault.in',
       searchUrl: 'https://api.vitpapervault.in/api/paper/list',
+      error: undefined,
     }
   } catch (err) {
     console.warn('List API failed (network/parse error), falling back:', err)
-    return { success: false, papers: [] }
+    const message = err instanceof Error ? err.message : 'Unknown API error'
+    return { success: false, papers: [], error: message }
   }
 }
 

--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -1,9 +1,5 @@
 import { tool } from 'ai'
 import { z } from 'zod'
-import { scrapePapersCodeChef } from './scrapers/papers-codechef'
-import { scrapePapersService } from './scrapers/papers-scraper'
-import { scrapeVITPaperVault } from './scrapers/vit-papervault'
-import { scrapeExamCooker } from './scrapers/examcooker'
 import { scrapePlacementInfo } from './scrapers/placement-scraper'
 import { getMessMenu, formatMenuItems, getAvailableDateRange } from './scrapers/mess-menu-scraper'
 import { getCourseCode } from './question-generator'
@@ -17,13 +13,35 @@ import { getCourseData, School } from './ffcs-tool'
 import { createKnowledgeTools } from './knowledge-tools'
 import { createMemoryTool } from './memory/memory-tools'
 import { hasVTOPCredentials, getFormattedVTOPCredentials } from './server-vtop-credentials'
-import {
-  indexPastPapers,
-  askIndexedPaperQuestion,
-  smartPaperSearchByQuestion,
-  getPaperIndexMeta,
-} from './agents/paper-agent'
-import { analyzeQuestionFrequencies } from './agents/question-frequency-agent'
+
+const paperScrapingEnabled = process.env.ENABLE_PAPER_SCRAPING === 'true'
+
+type PaperScraperDeps = {
+  scrapePapersService: typeof import('./scrapers/papers-scraper').scrapePapersService
+  scrapePapersCodeChef: typeof import('./scrapers/papers-codechef').scrapePapersCodeChef
+  scrapeVITPaperVault: typeof import('./scrapers/vit-papervault').scrapeVITPaperVault
+  scrapeExamCooker: typeof import('./scrapers/examcooker').scrapeExamCooker
+}
+
+let paperScraperDepsPromise: Promise<PaperScraperDeps> | null = null
+
+async function loadPaperScraperDeps(): Promise<PaperScraperDeps> {
+  if (!paperScraperDepsPromise) {
+    paperScraperDepsPromise = Promise.all([
+      import('./scrapers/papers-scraper'),
+      import('./scrapers/papers-codechef'),
+      import('./scrapers/vit-papervault'),
+      import('./scrapers/examcooker'),
+    ]).then(([paperScraper, codeChef, vitPaperVault, examCooker]) => ({
+      scrapePapersService: paperScraper.scrapePapersService,
+      scrapePapersCodeChef: codeChef.scrapePapersCodeChef,
+      scrapeVITPaperVault: vitPaperVault.scrapeVITPaperVault,
+      scrapeExamCooker: examCooker.scrapeExamCooker,
+    }))
+  }
+
+  return paperScraperDepsPromise
+}
 
 type ParsedPlacementData = {
   formatted_content: string
@@ -705,6 +723,9 @@ export function createVITTools(userId: string) {
         year,
       }: z.infer<typeof findPastPapersInputSchema>) => {
         try {
+          const { scrapePapersService, scrapePapersCodeChef, scrapeVITPaperVault, scrapeExamCooker } =
+            await loadPaperScraperDeps()
+
           if (!courseCode) {
             return {
               success: false,
@@ -742,12 +763,18 @@ export function createVITTools(userId: string) {
             }
           }
 
-          const results = await Promise.allSettled([
+          const sourcesToUse = [
             scrapePapersService(resolvedCourseCode, examType, year),
-            scrapePapersCodeChef(resolvedCourseCode, examType, year),
-            scrapeVITPaperVault(resolvedCourseCode, examType, year),
+            scrapePapersCodeChef(resolvedCourseCode, examType, year, {
+              enableBrowserFallback: paperScrapingEnabled,
+            }),
+            scrapeVITPaperVault(resolvedCourseCode, examType, year, {
+              enableBrowserFallback: paperScrapingEnabled,
+            }),
             scrapeExamCooker(resolvedCourseCode, examType, year),
-          ])
+          ]
+
+          const results = await Promise.allSettled(sourcesToUse)
 
           const papers: any[] = []
           const sources: any[] = []
@@ -755,7 +782,9 @@ export function createVITTools(userId: string) {
           results.forEach(r => {
             if (r.status === 'fulfilled' && r.value.success) {
               papers.push(...r.value.papers)
-              sources.push(r.value.source)
+              if (r.value.source) {
+                sources.push(r.value.source)
+              }
             }
           })
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,12 @@ const nextConfig: NextConfig = {
     turbopackFileSystemCacheForDev: true,
   },
   turbopack: {},
+  env: {
+    // Heavy headless-browser scrapers dramatically increase bundle size and are not
+    // suitable for Cloudflare Workers. Disable them by default and opt-in when
+    // deploying to a Node environment that can run Puppeteer/Chromium.
+    ENABLE_PAPER_SCRAPING: process.env.ENABLE_PAPER_SCRAPING ?? 'false',
+  },
   typescript: { ignoreBuildErrors: false },
   images: { unoptimized: true },
   reactCompiler: true,


### PR DESCRIPTION
## Summary
- keep API-powered paper sources active even when ENABLE_PAPER_SCRAPING is false
- add a browser-fallback toggle with lazy imports for CodeChef and VIT Paper Vault scrapers to avoid bundling heavy deps in lightweight builds
- route the public search endpoint and agent tool through the API-only paths when scraping is disabled

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba65a7d2c832da811a31f287c0c47)