### PR TITLE
Add WhatsApp !no command (NaaS)

### DIFF
--- a/services/wa-bot/README.md
+++ b/services/wa-bot/README.md
@@ -70,6 +70,7 @@ npm start
 Users can interact with the bot using these commands:
 
 - `!ask [question]` - Ask the AI assistant anything
+- `!no` - Get a random rejection reason
 - `!help` - Show available commands
 - `!status` - Check bot status
 

--- a/services/wa-bot/whatsapp-service.js
+++ b/services/wa-bot/whatsapp-service.js
@@ -678,6 +678,10 @@ class WhatsAppService extends EventEmitter {
         await this.sendStatusMessage(originalChat)
         break
 
+      case '!no':
+        await this.handleNoCommand(originalChat)
+        break
+
       case '!linkvtop':
       case '!vtoplink':
       case '!link':
@@ -784,6 +788,33 @@ class WhatsAppService extends EventEmitter {
         userChat,
         'something went wrong while creating the link. please try again in a bit.'
       )
+    }
+  }
+
+  async handleNoCommand(chat) {
+    const fallbackMessage =
+      "The API is down so I guess I'll just reject you manually - no"
+
+    try {
+      const response = await fetch('https://naas.isalman.dev/no', {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': 'WhatsApp-Bot-Service/1.0.0',
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`NaaS request failed: ${response.status} ${response.statusText}`)
+      }
+
+      const data = await response.json()
+      const reason = typeof data?.reason === 'string' ? data.reason.trim() : ''
+
+      await this.sendMessageToChat(chat, reason || fallbackMessage)
+    } catch (error) {
+      console.error('❌ Error in handleNoCommand:', error)
+      await this.sendMessageToChat(chat, fallbackMessage)
     }
   }
 
@@ -1268,6 +1299,9 @@ available commands:
    example: !context what were the main topics discussed?
    example: !context 400 summarize what happened while i was away
    example: !context limit=200 give me the finance updates
+
+!no - get a random rejection reason
+   example: !no
 
 !everyone [message] - tag everyone in group chat (owner only)
    example: !everyone meeting tomorrow at 5pm


### PR DESCRIPTION
## Summary

Adds a simple WhatsApp bot command, `!no`, which fetches a random rejection reason from [hotheadhacker/no-as-a-service](https://github.com/hotheadhacker/no-as-a-service) and sends it back in chat.

## Changes

- Added `!no` command handling in `services/wa-bot/whatsapp-service.js`
- Added `handleNoCommand(...)` to call `https://naas.isalman.dev/no`
- Added fallback reply when the external API fails:
  - `The API is down so I guess I'll just reject you manually - no`
- Updated WhatsApp help text to include `!no`
- Updated `services/wa-bot/README.md` to document the new command

## Behavior

- Works in both direct chats and group chats
- Can be used by any user
- Inherits the existing WhatsApp bot rate limiting and command flow
- Does not touch the shared AI route or Discord bot

## Testing

- Verified locally by running the WhatsApp bot
- Confirmed `!no` returns a response successfully in WhatsApp
- Confirmed fallback behavior is implemented for API failure cases

## NOTE

- There were whatsapp js version mismatches on my local so needed to make some changes to get it working locally, but reverted those before pushing so as to not mess up your deployment.